### PR TITLE
Changing references of citadel and tg to rogue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,4 +4,4 @@ about: Suggest an idea for this project
 
 ---
 
-Please be aware that feature discussions most often take place on the Citadel Station Discord and should not be requested here.
+Please be aware that feature discussions most often take place on the Rogue Life Discord and should not be requested here.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-## Citadel Station 13
+## Rogue Station 13
 Based and maintained from /tg/station.
 
-[![forthebadge](http://forthebadge.com/images/badges/60-percent-of-the-time-works-every-time.svg)](https://forthebadge.com) [![forthebadge](http://forthebadge.com/images/badges/pretty-risque.svg)](https://forthebadge.com) [![forthebadge](http://forthebadge.com/images/badges/you-didnt-ask-for-this.svg)](http://forthebadge.com)
+[![forthebadge](http://forthebadge.com/images/badges/60-percent-of-the-time-works-every-time.svg)](https://forthebadge.com)
 
 [![forinfinityandbyond](https://user-images.githubusercontent.com/5211576/29499758-4efff304-85e6-11e7-8267-62919c3688a9.gif)](https://www.reddit.com/r/SS13/comments/5oplxp/what_is_the_main_problem_with_byond_as_an_engine/dclbu1a)
 
-[![Build Status](https://api.travis-ci.org/Citadel-Station-13/Citadel-Station-13.png)](https://travis-ci.org/Citadel-Station-13/Citadel-Station-13) [![Krihelimeter](http://www.krihelinator.xyz/badge/Citadel-Station-13/Citadel-Station-13)](http://www.krihelinator.xyz)
 
-[![Percentage of issues still open](http://isitmaintained.com/badge/open/Citadel-Station-13/Citadel-Station-13.svg)](http://isitmaintained.com/project/Citadel-Station-13/Citadel-Station-13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/Citadel-Station-13/Citadel-Station-13.svg)](http://isitmaintained.com/project/Citadel-Station-13/Citadel-Station-13 "Average time to resolve an issue")
 
 **Upstream Information**  
 **Website:** https://tgstation13.org  
@@ -15,12 +13,12 @@ Based and maintained from /tg/station.
 **Wiki** https://tgstation13.org/wiki/Main_Page  
 **IRC:** irc://irc.rizon.net/coderbus or if you dont have an IRC client, you can click  [here](https://kiwiirc.com/client/irc.rizon.net:6667/?&theme=cli#coderbus).  
   
-**Citadel Station Information**  
-**Website:** http://citadel-station.net  
-**Forums:** http://citadel-station.net/forum  
-**Ban Appeals:** http://citadel-station.net/forum/forumdisplay.php?fid=8  
-**Code:** https://github.com/Citadel-Station-13/Citadel-Station-13  
-**Discord:**  [Here](https://discord.gg/E6SQuhz)  
+**Rogue Station Information**  
+**Website:**
+**Forums:**
+**Ban Appeals:**
+**Code:** https://github.com/Rogue-Life/Rogue-Station-Live  
+**Discord:**  [Here](https://discord.gg/tpScqXubX8)  
   
 ## DOWNLOADING
 
@@ -106,13 +104,11 @@ https://github.com/tgstation/tgstation-server
 
 ## MAPS
 
-/tg/station currently comes equipped with five maps.
+Rogue station currently comes equipped with three maps.
 
-* [BoxStation (default)](http://tgstation13.org/wiki/Boxstation)
-* [MetaStation](https://tgstation13.org/wiki/MetaStation)
-* [DeltaStation](https://tgstation13.org/wiki/DeltaStation)
-* [OmegaStation](https://tgstation13.org/wiki/OmegaStation)
-* [PubbyStation](https://tgstation13.org/wiki/PubbyStation)
+* [BoxStation](http://tgstation13.org/wiki/Boxstation)
+* [PubbyStation (defualt)](https://tgstation13.org/wiki/PubbyStation)
+* [Kilo Station]
 
 
 All maps have their own code file that is in the base of the _maps directory. Maps are loaded dynamically when the game starts. Follow this guideline when adding your own map, to your fork, for easy compatibility.
@@ -125,7 +121,7 @@ Anytime you want to make changes to a map it's imperative you use the [Map Mergi
 
 ## AWAY MISSIONS
 
-/tg/station supports loading away missions however they are disabled by default.
+Citadel supports loading away missions however they are disabled by default.
 
 Map files for away missions are located in the _maps/RandomZLevels directory. Each away mission includes it's own code definitions located in /code/modules/awaymissions/mission_code. These files must be included and compiled with the server beforehand otherwise the server will crash upon trying to load away missions that lack their code.
 

--- a/citadel/tools/merge-upstream-pull-request.sh
+++ b/citadel/tools/merge-upstream-pull-request.sh
@@ -49,7 +49,7 @@ curl -v \
 -H "User-Agent: myBotThing (http://some.url, v0.1)" \
 -H "Content-Type: application/json" \
 -X POST \
--d "{\"content\":\"Mirroring [$1] from /tg/ to Citadel\"}" \
+-d "{\"content\":\"Mirroring [$1] from /tg/ to Rogue\"}" \
 https://discordapp.com/api/channels/$CHANNELID/messages
 
 # We need to make sure we are always on a clean master when creating the new branch.

--- a/code/modules/antagonists/bloodsucker/powers/feed.dm
+++ b/code/modules/antagonists/bloodsucker/powers/feed.dm
@@ -158,11 +158,13 @@
 			target.Move(user.loc)
 	// Broadcast Message
 	if(amSilent)
-		//if (!iscarbon(target))
-		//	user.visible_message("<span class='notice'>[user] shifts [target] closer to [user.p_their()] mouth.</span>", \
-		//					 	 "<span class='notice'>You secretly slip your fangs into [target]'s flesh.</span>", \
-		//					 	 vision_distance = 2, ignored_mobs=target) // Only people who AREN'T the target will notice this action.
-		//else
+	/*
+		if (!iscarbon(target))
+			user.visible_message("<span class='notice'>[user] shifts [target] closer to [user.p_their()] mouth.</span>", \
+							 	 "<span class='notice'>You secretly slip your fangs into [target]'s flesh.</span>", \
+							 	 vision_distance = 2, ignored_mobs=target) // Only people who AREN'T the target will notice this action.
+		else
+	*/
 		var/deadmessage = target.stat == DEAD ? "" : " <i>[target.p_they(TRUE)] looks dazed, and will not remember this.</i>"
 		user.visible_message("<span class='notice'>[user] puts [target]'s wrist up to [user.p_their()] mouth.</span>", \
 						 	 "<span class='notice'>You secretly slip your fangs into [target]'s wrist.[deadmessage]</span>", \

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-  <title>Citadel Station 13 Changelog</title>
+  <title>Rogue Station 13 Changelog</title>
   <link rel="stylesheet" type="text/css" href="changelog.css">
   <base target="_blank" />
   <script type='text/javascript'>
@@ -23,9 +23,9 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<div align='center'><font size='3'><b>Traditional Games Space Station 13</b></font></div>
+			<div align='center'><font size='3'><b>Rogue Life Space Station 13</b></font></div>
 			
-			<p><div align='center'><font size='3'><a href="https://citadel-station.net/forum/index.php">Forum</a> | <a href="https://katlin.dog/citadel-wiki">Wiki</a> | <a href="https://github.com/Citadel-Station-13/Citadel-Station-13">Source</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="NULL">Forum</a> | <a href="https://katlin.dog/citadel-wiki">Wiki</a> | <a href="https://github.com/Rogue-Life/Rogue-Station-Live">Source</a></font></div></p>
 			</td>
 	</tr>
 </table>
@@ -34,9 +34,9 @@
 	<tr>
 		<td valign='top'>
 			<font size='2'><b>Thanks to:</b> /tg/station, Baystation 12, /vg/station, NTstation, CDK Station devs, FacepunchStation, GoonStation devs, the original SpaceStation developers and Invisty for the title image.<br> Also a thanks to anybody who has contributed.</font>
-			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Citadel-Station-13/Citadel-Station-13/issues">Issue Tracker</a>.<br></font>
-			<font size='2'>Please ensure that the bug has not already been reported, <u><a href="https://github.com/Citadel-Station-13/Citadel-Station-13/issues"><b> use the template provided here!</b></a></u>.</font>
-			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Citadel-Station-13/Citadel-Station-13/graphs/contributors'>-Click Here-</a><br></font>
+			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Rogue-Life/Rogue-Station-Live/issues">Issue Tracker</a>.<br></font>
+			<font size='2'>Please ensure that the bug has not already been reported, <u><a href="https://github.com/Rogue-Life/Rogue-Station-Live/issues"><b> use the template provided here!</b></a></u>.</font>
+			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Rogue-Life/Rogue-Station-Live/graphs/contributors'>-Click Here-</a><br></font>
 		</td>
 	</tr>
 </table>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-  <title>Citadel Station 13 Changelog</title>
+  <title>Rogue Station 13 Changelog</title>
   <link rel="stylesheet" type="text/css" href="changelog.css">
   <base target="_blank" />
   <script type='text/javascript'>
@@ -23,9 +23,9 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<div align='center'><font size='3'><b>Traditional Games Space Station 13</b></font></div>
+			<div align='center'><font size='3'><b>Rogue Life Space Station 13</b></font></div>
 			
-			<p><div align='center'><font size='3'><a href="https://citadel-station.net/forum/index.php">Forum</a> | <a href="https://citadel-station.net/wiki/index.php?title=Main_Page">Wiki</a> | <a href="https://github.com/Citadel-Station-13/Citadel-Station-13">Source</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="NULL">Forum</a> | <a href="https://citadel-station.net/wiki/index.php?title=Main_Page">Wiki</a> | <a href="https://github.com/Rogue-Life">Source</a></font></div></p>
 			</td>
 	</tr>
 </table>
@@ -34,9 +34,9 @@
 	<tr>
 		<td valign='top'>
 			<font size='2'><b>Thanks to:</b> /tg/station, Baystation 12, /vg/station, NTstation, CDK Station devs, FacepunchStation, GoonStation devs, the original SpaceStation developers and Invisty for the title image.<br> Also a thanks to anybody who has contributed.</font>
-			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Citadel-Station-13/Citadel-Station-13/issues">Issue Tracker</a>.<br></font>
-			<font size='2'>Please ensure that the bug has not already been reported, <u><a href="https://github.com/Citadel-Station-13/Citadel-Station-13/issues"><b> use the template provided here!</b></a></u>.</font>
-			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Citadel-Station-13/Citadel-Station-13/graphs/contributors'>-Click Here-</a><br></font>
+			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Rogue-Life/Rogue-Station-Live/issues">Issue Tracker</a>.<br></font>
+			<font size='2'>Please ensure that the bug has not already been reported, <u><a href="https://github.com/Rogue-Life/Rogue-Station-Live/issues"><b> use the template provided here!</b></a></u>.</font>
+			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Rogue-Life/Rogue-Station-Live/graphs/contributors'>-Click Here-</a><br></font>
 		</td>
 	</tr>
 </table>

--- a/tgui-next/packages/tgui/public/tgui-main.html
+++ b/tgui-next/packages/tgui/public/tgui-main.html
@@ -108,7 +108,7 @@ A fatal exception has occurred at 002B:C562F1B7 in TGUI.
 The current application will be terminated.
 Please remain calm, get to the nearest NTNet workstation
 and send the copy of the following stack trace to:
-https://github.com/Citadel-Station-13/Citadel-Station-13/issues Thank you for your cooperation.
+https://github.com/Rogue-Life/Rogue-Station-Live/issues Thank you for your cooperation.
 </marquee>
 <div id="FatalError__stack" class="FatalError__stack"></div>
 <div class="FatalError__footer">


### PR DESCRIPTION
some refrerences remain like wikis since we do not have the capacity to host or make our own